### PR TITLE
Defer UI updates to the end of the tick.

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -50,7 +50,7 @@ function Actions() {
                     partUpdateRequired = true;
                     if (curAction.canStart && !curAction.canStart()) {
                         this.completedTicks += curAction.ticks;
-                        view.updateTotalTicks();
+                        view.requestUpdate("updateTotalTicks", null);
                         curAction.loopsLeft = 0;
                         curAction.ticks = 0;
                         curAction.manaRemaining = timeNeeded - timer;
@@ -86,7 +86,7 @@ function Actions() {
             curAction.goldRemaining = resources.gold;
 
             this.adjustTicksNeeded();
-            view.updateCurrentActionLoops(this.currentPos);
+            view.requestUpdate("updateCurrentActionLoops", this.currentPos);
         }
         view.requestUpdate("updateCurrentActionBar", this.currentPos);
         if (curAction.loopsLeft === 0) {
@@ -219,7 +219,7 @@ function Actions() {
             remainingTicks += action.loopsLeft * action.adjustedTicks;
         }
         this.totalNeeded = this.completedTicks + remainingTicks;
-        view.updateTotalTicks();
+        view.requestUpdate("updateTotalTicks", null);
     };
 
 

--- a/driver.js
+++ b/driver.js
@@ -143,7 +143,7 @@ function prepareRestart() {
         }
         if (curAction) {
             actions.completedTicks += actions.getNextValidAction().ticks;
-            view.updateTotalTicks();
+            view.requestUpdate("updateTotalTicks", null);
         }
         for (let i = 0; i < actions.current.length; i++) {
             view.updateCurrentActionBar(i);

--- a/views/main.view.js
+++ b/views/main.view.js
@@ -115,7 +115,9 @@ function View() {
         updateMultiPartActions: [],
         updateNextActions: [],
         updateTime: [],
-        updateCurrentActionBar: []
+        updateCurrentActionBar: [],
+        updateTotalTicks: [],
+        updateCurrentActionLoops: []
     };
 
     // requesting an update will call that update on the next view.update tick (based off player set UPS)


### PR DESCRIPTION
Profiled with `gamespeed = 300`.

Parts of UI were updated and overwritten during calculations, so most of them were completely wasted, changed it so they only get updated once, at the end of tick.