### PR TITLE
Fix tooltip image jump on chrome? based browsers

### DIFF
--- a/driver.js
+++ b/driver.js
@@ -501,11 +501,15 @@ function handleDragStart(event) {
 }
 
 function handleDirectActionDragStart(event, actionName, townNum, actionVarName, isTravelAction) {
-    document.getElementById(`container${actionVarName}`).children[2].style.display = "none";
-    const actionData = { _actionName: actionName, _townNum: townNum, _isTravelAction: isTravelAction };
-    const serialData = JSON.stringify(actionData);
-    event.dataTransfer.setData("actionData", serialData);
-    hideActionIcons();
+	var element = document.getElementById(`container${actionVarName}`);
+	element.children[2].style.display = "none";
+
+ 	const actionData = { _actionName: actionName, _townNum: townNum, _isTravelAction: isTravelAction };
+  	const serialData = JSON.stringify(actionData);
+
+	event.dataTransfer.setDragImage(element, event.pageX - element.offsetLeft, event.pageY - element.offsetTop);
+ 	event.dataTransfer.setData("actionData", serialData);
+ 	hideActionIcons();
 }
 
 


### PR DESCRIPTION
This workaround fixes issue, reported by MakroCZ:
> When you are drag&dropping action into action list, icons are moved to the left when dragging them. But that is there for longer time
https://github.com/lloyd-delacroix/omsi-loops/pull/25#issuecomment-1364705468

Actual change is call to setDragImage.
So when you start dragging action browser creates a bitmap of dragged element. And this includes tooltip.  
Then tooltip is hidden. And for Chrome bitmap is moved to the top left corner of drag rectangle.